### PR TITLE
Fix#19 DisallowedHost error by adding localhost to ALLOWED_HOSTS

### DIFF
--- a/kopa/settings.py
+++ b/kopa/settings.py
@@ -13,12 +13,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'django-insecure-0v$%y-54p*=!td!**sguksonez0oaf=t1)vxab==g8qv+mpaq$'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
-ALLOWED_HOSTS = [
-    "mbadi.pythonanywhere.com",
-    "127.0.0.1"
-    ]
+ALLOWED_HOSTS = ['localhost', '127.0.0.1']
+
 
 
 # Application definition


### PR DESCRIPTION
Solution:
Update the ALLOWED_HOSTS setting in settings.py to include 'localhost' and '127.0.0.1', which are the typical domains used during local development.