### PR TITLE
Replace hardcoded SECRET_KEY in kopa/settings.py with environment variable

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ CORE_BANKING_KYC_PASSWORD=pwd123
 CORE_BANKING_USERNAME=admin
 CORE_BANKING_PASSWORD=pwd123
 CORE_BANKING_KYC_URL=https://kycapitest.credable.io/service/customerWsdl.wsdl
+DJANGO_SECRET_KEY='django-insecure-0v$%y-54p*=!td!**sguksonez0oaf=t1)vxab==g8qv+mpaq$'

--- a/kopa/settings.py
+++ b/kopa/settings.py
@@ -1,3 +1,8 @@
+import os
+
+from dotenv import load_dotenv
+load_dotenv()
+
 from pathlib import Path
 
 from datetime import timedelta
@@ -10,7 +15,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-0v$%y-54p*=!td!**sguksonez0oaf=t1)vxab==g8qv+mpaq$'
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "unsafe-default-key-for-dev-only")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
### What Changed
- Replaced hardcoded Django SECRET_KEY with environment variable using `os.environ.get`.
- Updated `.env.sample` with DJANGO_SECRET_KEY.
- Optional: Added `load_dotenv()` support for local development.

### Why This Matters
Hardcoding secrets is insecure. This change ensures better security and allows easier environment separation for dev/staging/production.

Fixes #36
